### PR TITLE
feature: show an edit button with the text of 'show_edit' when set

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ Get to work.
 themes/eon/scripts/development
 ```
 
+## Config
+
+```yaml
+theme: 'eon'
+Author:
+  name: 'John Doe'
+  email: 'john.doe@example.com'
+
+Params:
+  gravatar: true
+  # if you'd like a "Edit" or "Suggest Edit" link by your Titles
+  show_edit: 'Suggest Edit'
+  git_repo: 'https://github.com/YOUR_USER/YOUR_REPO'
+  git_branch: 'main'
+  git_host: 'github'
+```
+
+<kbd><img width="526" alt="Screen Shot 2021-08-03 at 12 13 53 AM" src="https://user-images.githubusercontent.com/122831/127966869-0ad9e971-88f5-40b9-9d9d-8e82810bbace.png"></kbd>
+
+#### Show Edit
+
+If you like having an edit button on your posts for convenience, set `show_edit`
+to the text you wish to display (you'll also need to set the `git_*` stuff in
+order to construct the link).
+
+If `git_repo`, etc are set, they will also appear in the `<head>` like this:
+
+```html
+<meta name="git_repo" content="https://github.com/YOUR_USER/YOUR_REPO" />
+```
+
 ## Global Dependencies
 
 You'll need Hugo and Node.js installed in your environment.

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="content">
       {{ partial "postmeta-head" . }}
-      <h1 class="title">{{ .Title }}</h1>
+      <h1 class="title">{{ .Title }} {{ partial "edit" . }}</h1>
       <!-- prettier-ignore -->
       {{ .Content }}
       <!-- prettier-ignore -->

--- a/layouts/partials/edit.html
+++ b/layouts/partials/edit.html
@@ -1,0 +1,18 @@
+{{ if (isset .Site.Params "git_repo") -}}
+<span class="edit" style='
+    vertical-align: middle;
+    font-size: 1rem;
+    padding: 0.5rem;
+    {{ if not (isset .Site.Params "show_edit") -}}
+      display: none;
+    {{- end }}
+  ' {{ if not (isset .Site.Params "show_edit") -}}
+    hidden
+  {{- end }}><a
+    {{ if eq .Site.Params.git_host "gitea" -}}
+        href="{{ .Site.Params.git_repo }}/_edit/{{ .Site.Params.git_branch }}/content/{{ .File.Dir }}{{ .File.LogicalName }}"
+    {{- else -}}
+        href="{{ .Site.Params.git_repo }}/edit/{{ .Site.Params.git_branch }}/content/{{ .File.Dir }}{{ .File.LogicalName }}"
+    {{- end }}
+    target="_blank">{{ .Site.Params.show_edit }}</a></span>
+{{- end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,4 @@
+<title>{{ if ne .Page.Title "" }}{{ .Page.Title }} - {{ end }}{{ .Site.Title }}</title>
 <meta name="viewport" content="width=device-width" />
 {{ if (isset .Params "redirect") }}
 <meta http-equiv="refresh" content="0;url={{ .Params.redirect }}" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,16 @@
 <title>{{ if ne .Page.Title "" }}{{ .Page.Title }} - {{ end }}{{ .Site.Title }}</title>
 <meta name="viewport" content="width=device-width" />
-{{ if (isset .Params "redirect") }}
-<meta http-equiv="refresh" content="0;url={{ .Params.redirect }}" />
-{{ end }}
+{{ if isset .Site.Params "redirect" -}}
+<meta http-equiv="refresh" content="0;url={{ .Site.Params.redirect }}" />
+{{- end }}
 <link rel="stylesheet" href='{{ "style.css" | absURL }}' />
+{{ if isset .Site.Params "git_repo" -}}
+<meta name="git_repo" content="{{ .Site.Params.git_repo }}" />
+{{ if isset .Site.Params "git_host" -}}
+<meta name="git_host" content="{{ .Site.Params.git_host }}" />
+{{- end }}
+{{ if isset .Site.Params "git_branch" -}}
+<meta name="git_branch" content="{{ .Site.Params.git_branch }}" />
+{{- end }}
+<meta name="content_path" content="content" />
+{{- end }}

--- a/layouts/partials/postmeta-foot.html
+++ b/layouts/partials/postmeta-foot.html
@@ -1,1 +1,5 @@
-<div class="postmeta-foot">{{- partial "categories" . -}}</div>
+<div class="postmeta-foot">
+
+  {{ partial "categories" . }}
+
+</div>

--- a/src/css/_postmeta-foot.scss
+++ b/src/css/_postmeta-foot.scss
@@ -1,4 +1,8 @@
 .postmeta-foot {
+  @extend .columns;
+  > div {
+    @extend .column;
+  }
   p,
   span,
   li {
@@ -13,5 +17,10 @@
   a:hover {
     color: $light-gray;
     text-decoration: underline;
+  }
+  .suggest-edit {
+    @include tablet {
+      text-align: right;
+    }
   }
 }


### PR DESCRIPTION
substitute for https://github.com/ryanburnette/eon/pull/16

- [x] `show_edit` will cause edit button to appear near title with the the text of `show_edit`
- [x] documentation for variables

<kbd><img width="526" alt="Screen Shot 2021-08-03 at 12 13 53 AM" src="https://user-images.githubusercontent.com/122831/127966869-0ad9e971-88f5-40b9-9d9d-8e82810bbace.png"></kbd>
