### PR TITLE
add utterences_repo to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Params:
   suggest_edit: 'Suggest Edit'
   git_branch: main
   git_host: github
-  git_repo: 'https://github.com/YOUR_USER/YOUR_REPO'
+  git_repo: 'https://github.com/<username>/<project>'
+  utterences_repo: '<username>/<project>'
 ```
 
 If `git_repo`, etc are set, they will also appear in the `<head>` like this:

--- a/layouts/partials/postmeta-foot.html
+++ b/layouts/partials/postmeta-foot.html
@@ -2,8 +2,8 @@
   {{ if isset .Site.Params "utterences_repo" }}
   <script src="https://utteranc.es/client.js"
     repo="{{ .Site.Params.utterences_repo }}"
-    {{ if isset .Page "utterences_term" -}}
-      issue-term="{{ .Page.utterences_term }}"
+    {{ if isset .Params "utterences_term" -}}
+      issue-term="{{ .Params.utterences_term }}"
     {{- else if isset .Site.Params "utterences_term" -}}
       issue-term="{{ .Site.Params.utterences_term }}"
     {{- else -}}

--- a/layouts/partials/postmeta-foot.html
+++ b/layouts/partials/postmeta-foot.html
@@ -1,4 +1,19 @@
 <div class="postmeta-foot">
+  {{ if isset .Site.Params "utterences_repo" }}
+  <script src="https://utteranc.es/client.js"
+    repo="{{ .Site.Params.utterences_repo }}"
+    {{ if isset .Page "utterences_term" -}}
+      issue-term="{{ .Page.utterences_term }}"
+    {{- else if isset .Site.Params "utterences_term" -}}
+      issue-term="{{ .Site.Params.utterences_term }}"
+    {{- else -}}
+      issue-term="pathname"
+    {{- end }}
+    theme="github-light"
+    crossorigin="anonymous"
+    async>
+  </script>
+  {{ end }}
   <div class="columns">
     <div class="column">
       {{ partial "categories" . }}


### PR DESCRIPTION
Preview at: https://github.com/coolaj86/eon/tree/patch-2

```yaml
# config.yaml
Params:
  utterences_repo: '<username>/<project>'
```

```html
<script src="https://utteranc.es/client.js"
        repo="<username>/<repo>"
        issue-term="pathname"
        theme="github-light"
        crossorigin="anonymous"
        async>
</script>
```

Also requested feedback on naming at https://github.com/utterance/utterances/issues/552.