### PR TITLE
[wip] feature: also use .GitInfo.lastmod when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ order to construct the link).
 ```yaml
 # config.yaml
 Params:
+  enableGitInfo: true
   suggest_edit: 'Suggest Edit'
   git_branch: main
   git_host: github

--- a/layouts/partials/date-lastmod.html
+++ b/layouts/partials/date-lastmod.html
@@ -1,3 +1,9 @@
-{{ if not (eq (.Params.date) (.Params.lastmod)) }}
-  <span class="date-lastmod">Updated {{ dateFormat "January 2, 2006" .Params.lastmod }}</span>
-{{ end }}
+{{ if isset .Params "lastmod" -}}
+  {{- if not (eq (.Params.date) (.Params.lastmod)) -}}
+    <span class="date-lastmod">Updated {{ dateFormat "January 2, 2006" .Params.lastmod }}</span>
+  {{- end -}}
+{{- else if isset .GitInfo "lastmod" -}}
+  {{- if not (eq (.Params.date) (.GitInfo.lastmod)) -}}
+    <span class="date-lastmod">Updated {{ dateFormat "January 2, 2006" .GitInfo.lastmod }}</span>
+  {{- end -}}
+{{- end }}


### PR DESCRIPTION
Preview at: https://github.com/coolaj86/eon/tree/patch-2

Precedence:
- .Page.lastmod (if different)
- .GitInfo.lastmod (always different)
- nothing

I'm thinking about switching this around so that .GitInfo.lastmod supersedes .Page.lastmod on the basis that .GitInfo.lastmod is more likely to be up-to-date.

However, that also seems to violate the principle of least surprise: explicit > implicit.