### PR TITLE
feature: show edit in post meta header

### DIFF
--- a/layouts/partials/postmeta-head.html
+++ b/layouts/partials/postmeta-head.html
@@ -3,5 +3,6 @@
     {{ partial "author" . }}
     {{ partial "date-lastmod" . }}
     {{ partial "date" . }}
+    {{ partial "show-edit" . }}
   </p>
 </div>

--- a/layouts/partials/show-edit.html
+++ b/layouts/partials/show-edit.html
@@ -1,0 +1,16 @@
+{{ if (isset .Site.Params "git_repo") -}}
+<span class="edit" style='
+    {{ if not (isset .Site.Params "show_edit") -}}
+      display: none;
+    {{- end }}
+  ' {{ if not (isset .Site.Params "show_edit") -}}
+    hidden
+  {{- end }}><a
+    {{ if eq .Site.Params.git_host "gitea" -}}
+        href="{{ .Site.Params.git_repo }}/_edit/{{ .Site.Params.git_branch }}/content/{{ .File.Dir }}{{ .File.LogicalName }}"
+    {{- else -}}
+        href="{{ .Site.Params.git_repo }}/edit/{{ .Site.Params.git_branch }}/content/{{ .File.Dir }}{{ .File.LogicalName }}"
+    {{- end }}
+    style="color: #485fc7;"
+    target="_blank">{{ .Site.Params.show_edit }}</a></span>
+{{- end }}


### PR DESCRIPTION
perhaps this should re-use `suggest_edit`? or replace the current `suggest_edit` link?